### PR TITLE
enable to add members at editing groups

### DIFF
--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,24 +1,31 @@
-.chat-group-form
-  %h1 チャットグループ編集
-  = form_for @group do |f|
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        = f.label :name, "グループ名", class: "chat-group-form__label", for: "chat_group_name"
-      .chat-group-form__field--right
-        = f.text_field :name, class: "chat-group-form__input", id: "chat_group_name", placeholder: "グループ名を入力してください"
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
-        -# = f.label :name, "チャットメンバーを追加", class: "chat-group-form__label", for: "user-search-field"
-      .chat-group-form__field--right
-        .chat-group-form__search.clearfix
-          %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
-          -# = f.text_field :name, class: "chat-group-form__input", id: "user-search-field", placeholder: "追加したいユーザー名を入力してください"
-        #user-search-result
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        = f.label :name , "チャットメンバー", class: "chat-group-form__label", for: "chat_group_チャットメンバー"
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        = f.submit class: "chat-group-form__action-btn", value: "Save", name: "commit"
+.layout-notification
+  .chat-group-form
+    %h1 チャットグループ編集
+    = form_for @group do |f|
+      .chat-group-form__field.clearfix
+        .chat-group-form__field--left
+          = f.label :name, "グループ名", class: "chat-group-form__label"
+        .chat-group-form__field--right
+          = f.text_field :name, class: "chat-group-form__input", placeholder: "グループ名を入力してください"
+      -# .chat-group-form__field.clearfix
+      -#   .chat-group-form__field--left
+      -#     %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+      -#     -# = f.label :name, "チャットメンバーを追加", class: "chat-group-form__label", for: "user-search-field"
+      -#   .chat-group-form__field--right
+      -#     .chat-group-form__search.clearfix
+      -#       %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+      -#       -# = f.text_field :name, class: "chat-group-form__input", id: "user-search-field", placeholder: "追加したいユーザー名を入力してください"
+      -#     #user-search-result
+      .chat-group-form__field.clearfix
+        .chat-group-form__field--left
+          = f.label :name , "チャットメンバー", class: "chat-group-form__label"
+        .chat-group-form__field--right
+          #chat-group-users
+            #chat-group-user-22.chat-group-user.clearfix
+              %p.chat-group-user__name
+              = collection_check_boxes(:group, :user_ids, User.all, :id, :name) do |b|
+                = b.label(class: "chat-group-user__name"){ b.check_box + b.text }
+      .chat-group-form__field.clearfix
+        .chat-group-form__field--left
+        .chat-group-form__field--right
+          = f.submit class: "chat-group-form__action-btn", value: "Save", name: "commit"


### PR DESCRIPTION
# WHAT
グループ編集時にメンバー追加を可能にする
# WHY
ユーザー利便性向上の為